### PR TITLE
Allow disabling IP detection via env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ The default parameters can be overridden by setting environment variables on the
  * **DUCKDNS_TOKEN** - DuckDNS authentication token copied from duckdns.org -> install -> linux cron, e.g. 1234abcd-abcd-1234-abcd-123456789abc
  * **DUCKDNS_IP** - IP-address to update with. Defaults to the IP-address of the Docker host machine.
  * **DUCKDNS_UPDATE_INTERVAL=600** - Interval in seconds to sleep between updates. Defaults to 1800 seconds = 30 minutes.
+ * **DUCKDNS_REMOTE_DETECT_IP** - `false` will let the container determine the
+   external IP to be passed to Duck DNS. `true` will skip this logic and let
+   Duck DNS determine the IP. (Defaults to `false`.)
 
 ## Deployment
 

--- a/launch.sh
+++ b/launch.sh
@@ -27,7 +27,8 @@ while true; do
 	fi
 
 	echo "Calling URL: $URL"
-	curl -s -k "$URL" & wait
+	RESPONSE=$(curl -s -k "$URL" & wait)
+	echo "Duck DNS response: ${RESPONSE}"
 
 	# Sleep and loop
 	sleep $DUCKDNS_UPDATE_INTERVAL & wait

--- a/launch.sh
+++ b/launch.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 DUCKDNS_UPDATE_INTERVAL=${DUCKDNS_UPDATE_INTERVAL:-1800}
+DUCKDNS_REMOTE_DETECT_IP=${DUCKDNS_REMOTE_DETECT_IP:-false}
 
 if [ -z "$DUCKDNS_DOMAIN" ]; then
 	echo 'Please supply the $DUCKDNS_DOMAIN environment variable'
@@ -12,16 +13,19 @@ if [ -z "$DUCKDNS_TOKEN" ]; then
 fi
 
 while true; do
-	MACHINE_IP=$(ip route get 8.8.8.8 | awk '/8.8.8.8/ {print $NF}')
-	IP=${DUCKDNS_IP:-$MACHINE_IP}
-	if [ -z "$IP" ]; then
-		echo "Failed to find public IP. Is networking up yet?"
-		exit 1
+	URL="https://www.duckdns.org/update?domains=${DUCKDNS_DOMAIN}&token=${DUCKDNS_TOKEN}"
+	if [ "$DUCKDNS_REMOTE_DETECT_IP" = "false" ]; then
+		MACHINE_IP=$(ip route get 8.8.8.8 | awk '/8.8.8.8/ {print $NF}')
+		IP=${DUCKDNS_IP:-$MACHINE_IP}
+		if [ -z "$IP" ]; then
+			echo "Failed to find public IP. Is networking up yet?"
+			exit 1
+		fi
+
+		echo "Using IP: $IP"
+		URL="${URL}&ip=${IP}"
 	fi
 
-	echo "Using IP: $IP"
-
-	URL="https://www.duckdns.org/update?domains=${DUCKDNS_DOMAIN}&token=${DUCKDNS_TOKEN}&ip=${IP}"
 	echo "Calling URL: $URL"
 	curl -s -k "$URL" & wait
 


### PR DESCRIPTION
The internal IP detection was not working for me (it was resolving the IP to `172.18.0.2`).

I tried to disable the IP detection logic and let Duck DNS find out the IP and this seemed to work well for me. I decided to turn it into an option in case you want to make it part of the project.

Passing `DUCKDNS_REMOTE_DETECT_IP=true` will disable IP detection within the container and will let Duck DNS determine the IP of the caller.

The pull request also slightly improves the output of the curl command, which would previously be displayed as part of the next `echo` command, due to a lack of a newline character in the server response.